### PR TITLE
Update usage docs w.r.t. making helpers available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Paul Revere provides...
 So the flow would be...
 
 * Install the gem
+* Add `helper :announcements` either to application_controller.rb or to the specific controllers where you want to make the announcement helpers available
 * Use those partials in the correct places in your view code and mailer view code where you want announcements to show up
 * When you want to make an announcement, use the rails console to create a new Announcement record
 


### PR DESCRIPTION
It appears that in commit 8b44ee0631 a rather important bit of documentation was lost about making the helpers available by adding `helper :announcements` in the relevant controllers ([engine helpers aren't loaded by default](http://robots.thoughtbot.com/post/159805560/tips-for-writing-your-own-rails-engine)).

If the helpers aren't going to be loaded automagically—[as they used to be](https://github.com/thoughtbot/paul_revere/commit/4a8e4eb92f222c6f885ea8a9584d4405949207c4#diff-7)—then the docs should inform the user how to make them available.
