### PR TITLE
Rails whitelists attributes now

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,4 +1,6 @@
 class Announcement < ActiveRecord::Base
+  attr_accessible :body
+
   def self.current
     first(:order => 'created_at DESC') || new
   end

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -13,4 +13,8 @@ ActiveRecord::Base.establish_connection(
   :database => ":memory:"
 )
 
+ActiveSupport.on_load(:active_record) do
+  attr_accessible(nil)
+end
+
 CreateAnnouncements.suppress_messages { CreateAnnouncements.up }

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -4,19 +4,32 @@ require File.join(File.dirname(__FILE__), '..', '..', 'app', 'models', 'announce
 
 describe Announcement do
   it "should return the latest announcement when there are several" do
-    old = Announcement.create!(:body => 'no fun', :created_at => 2.days.ago)
-    latest = Announcement.create!(:body => 'fun', :created_at => 1.day.ago)
-    older = Announcement.create!(:body => 'less fun', :created_at => 3.days.ago)
+    old = create_announcement(:body => 'no fun', :created_at => 2.days.ago)
+    latest = create_announcement(:body => 'fun', :created_at => 1.day.ago)
+    older = create_announcement(:body => 'less fun', :created_at => 3.days.ago)
 
     Announcement.current.should == latest
   end
 
   it "should return an existent announcement where there is no announcement" do
-    Announcement.create!(:body => 'body')
+    create_announcement(:body => 'body')
     Announcement.current.exists?.should == true
   end
 
   it "should return a non-existent announcement where there is no announcement" do
     Announcement.current.exists?.should be_false
+  end
+
+  it 'can always assign straight to the body' do
+    Announcement.create!(:body => 'hello').body.should == 'hello'
+  end
+
+  def create_announcement(attributes)
+    announcement = Announcement.new
+    attributes.each do |key, value|
+      announcement.send("#{key}=", value)
+    end
+    announcement.save!
+    announcement
   end
 end


### PR DESCRIPTION
Rails defaults to a whitelist now, which makes `Annoucement` more annoying to create from irb. This resolves that.
