### PR TITLE
Problem with cookie name

### DIFF
--- a/app/helpers/announcements_helper.rb
+++ b/app/helpers/announcements_helper.rb
@@ -1,6 +1,6 @@
 module AnnouncementsHelper
   def announcement_hidden?(announcement)
-    cookies["announcement_#{announcement.created_at}"] == "hidden"
+    cookies["announcement_#{announcement.cookie_identifier}"] == "hidden"
   end
 
   def current_announcement

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -4,6 +4,10 @@ class Announcement < ActiveRecord::Base
   def self.current
     first(:order => 'created_at DESC') || new
   end
+  
+  def cookie_identifier
+    self.created_at.strftime("%Y%m%d%H%M%S")
+  end
 
   def exists?
     !new_record?

--- a/app/views/announcements/_announcement_for_all.html.erb
+++ b/app/views/announcements/_announcement_for_all.html.erb
@@ -2,7 +2,7 @@
   <div id="announcement">
     <span><%= current_announcement.body.html_safe %></span>
     <span class="hide">
-      <%= link_to_function "hide", "hideAnnouncement('announcement_#{current_announcement.created_at}')" %>
+      <%= link_to_function "hide", "hideAnnouncement('announcement_#{current_announcement.cookie_identifier}')" %>
     </span>
   </div>
 <% end %>

--- a/spec/helpers/announcements_helper_spec.rb
+++ b/spec/helpers/announcements_helper_spec.rb
@@ -24,7 +24,7 @@ describe AnnouncementsHelper do
     end
 
     describe "and the user has hidden an announcement" do
-      before { helper.stubs(:cookies).returns("announcement_#{@announcement.created_at}" => "hidden") }
+      before { helper.stubs(:cookies).returns("announcement_#{@announcement.cookie_identifier}" => "hidden") }
 
       it "should return true when sent announcement_hidden? with announcement" do
         helper.announcement_hidden?(@announcement).should be_true
@@ -32,7 +32,7 @@ describe AnnouncementsHelper do
     end
 
     describe "and the user has not hidden an announcement" do
-      before { helper.stubs(:cookies).returns("announcement_#{@announcement.created_at}" => "not hidden") }
+      before { helper.stubs(:cookies).returns("announcement_#{@announcement.cookie_identifier}" => "not hidden") }
 
       it "should return false when sent announcement_hidden? with announcement" do
         helper.announcement_hidden?(@announcement).should be_false


### PR DESCRIPTION
I run into problems when using the gem because the cookie name (which is the created_at timestamp of the announcement). I've introduced a cookie_identifier attribute which does the trick.
