### PR TITLE
Bump to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased:
 
+## 3.0.0:
+
 ### Added
 
 - Add support for Rails version 5.2.x

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paul_revere (2.1.0)
+    paul_revere (3.0.0)
       rails (>= 5.0, < 6.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ The names and logos for thoughtbot are trademarks of thoughtbot, inc.
 
 ## License
 
-Paul Revere is Copyright © 2009 thoughtbot, inc. It is free software, and may be
+Paul Revere is Copyright © 2009-2018 thoughtbot, inc. It is free software, and may be
 redistributed under the terms specified in the MIT-LICENSE file.

--- a/lib/paul_revere/version.rb
+++ b/lib/paul_revere/version.rb
@@ -1,3 +1,3 @@
 module PaulRevere
-  VERSION = "2.1.0".freeze
+  VERSION = "3.0.0".freeze
 end


### PR DESCRIPTION
*Added*

- Add support for Rails version 5.2.x

*Removed*

- Drop explicit support for ruby versions under 2.3.x
- Drop support for Rails versions under 5.0.x