### PR TITLE
Call dynamic-readme reusable workflow

### DIFF
--- a/.github/workflows/sb-dynamic-readme-workflow
+++ b/.github/workflows/sb-dynamic-readme-workflow
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -71,17 +71,10 @@ current session to view announcements.  The built-in implementation just checks
 that `current_user` is truth-y. Override that helper method if you want to do
 something more interesting as a check here.
 
-## Credits
-
-![thoughtbot](http://thoughtbot.com/images/tm/logo.png)
-
-Paul Revere is maintained and funded by [thoughtbot, inc](http://thoughtbot.com/community)
-
-Thank you to all [the contributors](https://github.com/thoughtbot/paul_revere/contributors)!
-
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
-
 ## License
 
-Paul Revere is Copyright © 2009-2020 thoughtbot, inc. It is free software, and may be
+Paul Revere is Copyright © 2009-2024 thoughtbot, inc. It is free software, and may be
 redistributed under the terms specified in the MIT-LICENSE file.
+
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ something more interesting as a check here.
 
 ## License
 
-Paul Revere is Copyright © 2009-2024 thoughtbot, inc. It is free software, and may be
+Paul Revere is Copyright © 2009 thoughtbot, inc. It is free software, and may be
 redistributed under the terms specified in the MIT-LICENSE file.
 
 <!-- START /templates/footer.md -->


### PR DESCRIPTION
We want to have a way to edit our README footer at one place and have the changes from there be propagated to our repos.

By adding this snippet in the README, we call this reusable workflow: https://github.com/thoughtbot/templates/blob/main/.github/workflows/dynamic-readme.yaml that renders and updates the README footer dynamically.